### PR TITLE
Add fold length threshold setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This extension contributes the following settings:
 -   `tailwind-fold.foldedTextBackgroundColor`: Background color of the text when folded
 -   `tailwind-fold.unfoldedTextOpacity`: Opacity of unfolded class attributes
 -   `tailwind-fold.supportedLanguages`: Array of languages the extension is enabled for
+-   `tailwind-fold.foldLengthThreshold`: Specifies the minimum number of classes required for a section to be unfolded instead of folded.
 
 ## Note
 

--- a/package.json
+++ b/package.json
@@ -1,141 +1,147 @@
 {
-    "name": "tailwind-fold",
-    "displayName": "Tailwind Fold",
-    "description": "Improves code readability by folding class attributes",
-    "version": "0.0.2",
-    "icon": "images/icon.png",
-    "publisher": "stivo",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/stivoat/tailwind-fold"
-    },
-    "engines": {
-        "vscode": "^1.74.0"
-    },
-    "categories": [
-        "Formatters"
-    ],
-    "keywords": [
-        "tailwind",
-        "fold",
-        "clean code",
-        "pretty",
-        "inline css"
-    ],
-    "activationEvents": [
-        "onStartupFinished"
-    ],
-    "main": "./out/extension.js",
-    "contributes": {
-        "commands": [
-            {
-                "command": "tailwind-fold.toggleAutoFold",
-                "title": "Toggles automatic class attribute folding"
-            }
-        ],
-        "keybindings": [
-            {
-                "command": "tailwind-fold.toggleAutoFold",
-                "key": "ctrl+alt+a"
-            }
-        ],
-        "configuration": {
-            "title": "Tailwind Fold Settings",
-            "properties": {
-                "tailwind-fold.autoFold": {
-                    "order": 1,
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Automatically folds class attributes"
-                },
-                "tailwind-fold.foldStyle": {
-                    "order": 2,
-                    "type": "string",
-                    "default": "ALL",
-                    "description": "Whether to fold entire class attribute or only content in quotes",
-                    "enum": [
-                        "ALL",
-                        "QUOTES"
-                    ]
-                },
-                "tailwind-fold.unfoldIfLineSelected": {
-                    "order": 3,
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Automatically unfolds when the line is selected"
-                },
-                "tailwind-fold.showTailwindImage": {
-                    "order": 4,
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Shows tailwind image before folded text"
-                },
-                "tailwind-fold.foldedText": {
-                    "order": 5,
-                    "type": "string",
-                    "default": "...",
-                    "description": "Text to show when folded"
-                },
-                "tailwind-fold.foldedTextColor": {
-                    "order": 6,
-                    "type": "string",
-                    "default": "#7cdbfe7e",
-                    "description": "Color of folded text"
-                },
-                "tailwind-fold.foldedTextBackgroundColor": {
-                    "order": 7,
-                    "type": "string",
-                    "default": "#52b7ee09",
-                    "description": "Background color of folded section"
-                },
-                "tailwind-fold.unfoldedTextOpacity": {
-                    "order": 8,
-                    "type": "number",
-                    "default": 1,
-                    "description": "Formats class list when unfolded",
-                    "minimum": 0,
-                    "maximum": 1
-                },
-                "tailwind-fold.supportedLanguages": {
-                    "order": 9,
-                    "type": "array",
-                    "default": [
-                        "html",
-                        "typescriptreact",
-                        "javascriptreact",
-                        "typescript",
-                        "javascript",
-                        "vue-html",
-                        "vue",
-                        "php",
-                        "markdown",
-                        "coffeescript",
-                        "svelte"
-                    ],
-                    "description": "Supported languages"
-                }
-            }
-        }
-    },
-    "scripts": {
-        "vscode:prepublish": "npm run compile",
-        "compile": "tsc -p ./",
-        "watch": "tsc -watch -p ./",
-        "pretest": "npm run compile && npm run lint",
-        "lint": "eslint src --ext ts",
-        "test": "node ./out/test/runTest.js"
-    },
-    "devDependencies": {
-        "@types/vscode": "^1.74.0",
-        "@types/glob": "^8.0.0",
-        "@types/mocha": "^10.0.1",
-        "@types/node": "16.x",
-        "@typescript-eslint/eslint-plugin": "^5.45.0",
-        "@typescript-eslint/parser": "^5.45.0",
-        "eslint": "^8.28.0",
-        "glob": "^8.0.3",
-        "mocha": "^10.1.0",
-        "typescript": "^4.9.3",
-        "@vscode/test-electron": "^2.2.0"
-    }
+	"name": "tailwind-fold",
+	"displayName": "Tailwind Fold",
+	"description": "Improves code readability by folding class attributes",
+	"version": "0.0.2",
+	"icon": "images/icon.png",
+	"publisher": "stivo",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/stivoat/tailwind-fold"
+	},
+	"engines": {
+		"vscode": "^1.74.0"
+	},
+	"categories": [
+		"Formatters"
+	],
+	"keywords": [
+		"tailwind",
+		"fold",
+		"clean code",
+		"pretty",
+		"inline css"
+	],
+	"activationEvents": [
+		"onStartupFinished"
+	],
+	"main": "./out/extension.js",
+	"contributes": {
+		"commands": [
+			{
+				"command": "tailwind-fold.toggleAutoFold",
+				"title": "Toggles automatic class attribute folding"
+			}
+		],
+		"keybindings": [
+			{
+				"command": "tailwind-fold.toggleAutoFold",
+				"key": "ctrl+alt+a"
+			}
+		],
+		"configuration": {
+			"title": "Tailwind Fold Settings",
+			"properties": {
+				"tailwind-fold.autoFold": {
+					"order": 1,
+					"type": "boolean",
+					"default": true,
+					"description": "Automatically folds class attributes"
+				},
+				"tailwind-fold.foldStyle": {
+					"order": 2,
+					"type": "string",
+					"default": "ALL",
+					"description": "Whether to fold entire class attribute or only content in quotes",
+					"enum": [
+						"ALL",
+						"QUOTES"
+					]
+				},
+				"tailwind-fold.unfoldIfLineSelected": {
+					"order": 3,
+					"type": "boolean",
+					"default": false,
+					"description": "Automatically unfolds when the line is selected"
+				},
+				"tailwind-fold.showTailwindImage": {
+					"order": 4,
+					"type": "boolean",
+					"default": true,
+					"description": "Shows tailwind image before folded text"
+				},
+				"tailwind-fold.foldedText": {
+					"order": 5,
+					"type": "string",
+					"default": "...",
+					"description": "Text to show when folded"
+				},
+				"tailwind-fold.foldedTextColor": {
+					"order": 6,
+					"type": "string",
+					"default": "#7cdbfe7e",
+					"description": "Color of folded text"
+				},
+				"tailwind-fold.foldedTextBackgroundColor": {
+					"order": 7,
+					"type": "string",
+					"default": "#52b7ee09",
+					"description": "Background color of folded section"
+				},
+				"tailwind-fold.unfoldedTextOpacity": {
+					"order": 8,
+					"type": "number",
+					"default": 1,
+					"description": "Formats class list when unfolded",
+					"minimum": 0,
+					"maximum": 1
+				},
+				"tailwind-fold.supportedLanguages": {
+					"order": 9,
+					"type": "array",
+					"default": [
+						"html",
+						"typescriptreact",
+						"javascriptreact",
+						"typescript",
+						"javascript",
+						"vue-html",
+						"vue",
+						"php",
+						"markdown",
+						"coffeescript",
+						"svelte"
+					],
+					"description": "Supported languages"
+				},
+				"tailwind-fold.foldLengthThreshold": {
+					"order": 10,
+					"type": "number",
+					"default": 0,
+					"description": "Specifies the minimum number of classes required for a section to be unfolded instead of folded."
+				}
+			}
+		}
+	},
+	"scripts": {
+		"vscode:prepublish": "npm run compile",
+		"compile": "tsc -p ./",
+		"watch": "tsc -watch -p ./",
+		"pretest": "npm run compile && npm run lint",
+		"lint": "eslint src --ext ts",
+		"test": "node ./out/test/runTest.js"
+	},
+	"devDependencies": {
+		"@types/vscode": "^1.74.0",
+		"@types/glob": "^8.0.0",
+		"@types/mocha": "^10.0.1",
+		"@types/node": "16.x",
+		"@typescript-eslint/eslint-plugin": "^5.45.0",
+		"@typescript-eslint/parser": "^5.45.0",
+		"eslint": "^8.28.0",
+		"glob": "^8.0.3",
+		"mocha": "^10.1.0",
+		"typescript": "^4.9.3",
+		"@vscode/test-electron": "^2.2.0"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "tailwind-fold",
 	"displayName": "Tailwind Fold",
 	"description": "Improves code readability by folding class attributes",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"icon": "images/icon.png",
 	"publisher": "stivo",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -6,142 +6,142 @@
 	"icon": "images/icon.png",
 	"publisher": "stivo",
 	"repository": {
-		"type": "git",
-		"url": "https://github.com/stivoat/tailwind-fold"
+			"type": "git",
+			"url": "https://github.com/stivoat/tailwind-fold"
 	},
 	"engines": {
-		"vscode": "^1.74.0"
+			"vscode": "^1.74.0"
 	},
 	"categories": [
-		"Formatters"
+			"Formatters"
 	],
 	"keywords": [
-		"tailwind",
-		"fold",
-		"clean code",
-		"pretty",
-		"inline css"
+			"tailwind",
+			"fold",
+			"clean code",
+			"pretty",
+			"inline css"
 	],
 	"activationEvents": [
-		"onStartupFinished"
+			"onStartupFinished"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
-		"commands": [
-			{
-				"command": "tailwind-fold.toggleAutoFold",
-				"title": "Toggles automatic class attribute folding"
+			"commands": [
+					{
+							"command": "tailwind-fold.toggleAutoFold",
+							"title": "Toggles automatic class attribute folding"
+					}
+			],
+			"keybindings": [
+					{
+							"command": "tailwind-fold.toggleAutoFold",
+							"key": "ctrl+alt+a"
+					}
+			],
+			"configuration": {
+					"title": "Tailwind Fold Settings",
+					"properties": {
+							"tailwind-fold.autoFold": {
+									"order": 1,
+									"type": "boolean",
+									"default": true,
+									"description": "Automatically folds class attributes"
+							},
+							"tailwind-fold.foldStyle": {
+									"order": 2,
+									"type": "string",
+									"default": "ALL",
+									"description": "Whether to fold entire class attribute or only content in quotes",
+									"enum": [
+											"ALL",
+											"QUOTES"
+									]
+							},
+							"tailwind-fold.unfoldIfLineSelected": {
+									"order": 3,
+									"type": "boolean",
+									"default": false,
+									"description": "Automatically unfolds when the line is selected"
+							},
+							"tailwind-fold.showTailwindImage": {
+									"order": 4,
+									"type": "boolean",
+									"default": true,
+									"description": "Shows tailwind image before folded text"
+							},
+							"tailwind-fold.foldedText": {
+									"order": 5,
+									"type": "string",
+									"default": "...",
+									"description": "Text to show when folded"
+							},
+							"tailwind-fold.foldedTextColor": {
+									"order": 6,
+									"type": "string",
+									"default": "#7cdbfe7e",
+									"description": "Color of folded text"
+							},
+							"tailwind-fold.foldedTextBackgroundColor": {
+									"order": 7,
+									"type": "string",
+									"default": "#52b7ee09",
+									"description": "Background color of folded section"
+							},
+							"tailwind-fold.unfoldedTextOpacity": {
+									"order": 8,
+									"type": "number",
+									"default": 1,
+									"description": "Formats class list when unfolded",
+									"minimum": 0,
+									"maximum": 1
+							},
+							"tailwind-fold.supportedLanguages": {
+									"order": 9,
+									"type": "array",
+									"default": [
+											"html",
+											"typescriptreact",
+											"javascriptreact",
+											"typescript",
+											"javascript",
+											"vue-html",
+											"vue",
+											"php",
+											"markdown",
+											"coffeescript",
+											"svelte"
+									],
+									"description": "Supported languages"
+							},
+							"tailwind-fold.foldLengthThreshold": {
+								"order": 10,
+								"type": "number",
+								"default": 0,
+								"description": "Specifies the minimum number of classes required for a section to be unfolded instead of folded."
+							}
+					}
 			}
-		],
-		"keybindings": [
-			{
-				"command": "tailwind-fold.toggleAutoFold",
-				"key": "ctrl+alt+a"
-			}
-		],
-		"configuration": {
-			"title": "Tailwind Fold Settings",
-			"properties": {
-				"tailwind-fold.autoFold": {
-					"order": 1,
-					"type": "boolean",
-					"default": true,
-					"description": "Automatically folds class attributes"
-				},
-				"tailwind-fold.foldStyle": {
-					"order": 2,
-					"type": "string",
-					"default": "ALL",
-					"description": "Whether to fold entire class attribute or only content in quotes",
-					"enum": [
-						"ALL",
-						"QUOTES"
-					]
-				},
-				"tailwind-fold.unfoldIfLineSelected": {
-					"order": 3,
-					"type": "boolean",
-					"default": false,
-					"description": "Automatically unfolds when the line is selected"
-				},
-				"tailwind-fold.showTailwindImage": {
-					"order": 4,
-					"type": "boolean",
-					"default": true,
-					"description": "Shows tailwind image before folded text"
-				},
-				"tailwind-fold.foldedText": {
-					"order": 5,
-					"type": "string",
-					"default": "...",
-					"description": "Text to show when folded"
-				},
-				"tailwind-fold.foldedTextColor": {
-					"order": 6,
-					"type": "string",
-					"default": "#7cdbfe7e",
-					"description": "Color of folded text"
-				},
-				"tailwind-fold.foldedTextBackgroundColor": {
-					"order": 7,
-					"type": "string",
-					"default": "#52b7ee09",
-					"description": "Background color of folded section"
-				},
-				"tailwind-fold.unfoldedTextOpacity": {
-					"order": 8,
-					"type": "number",
-					"default": 1,
-					"description": "Formats class list when unfolded",
-					"minimum": 0,
-					"maximum": 1
-				},
-				"tailwind-fold.supportedLanguages": {
-					"order": 9,
-					"type": "array",
-					"default": [
-						"html",
-						"typescriptreact",
-						"javascriptreact",
-						"typescript",
-						"javascript",
-						"vue-html",
-						"vue",
-						"php",
-						"markdown",
-						"coffeescript",
-						"svelte"
-					],
-					"description": "Supported languages"
-				},
-				"tailwind-fold.foldLengthThreshold": {
-					"order": 10,
-					"type": "number",
-					"default": 0,
-					"description": "Specifies the minimum number of classes required for a section to be unfolded instead of folded."
-				}
-			}
-		}
 	},
 	"scripts": {
-		"vscode:prepublish": "npm run compile",
-		"compile": "tsc -p ./",
-		"watch": "tsc -watch -p ./",
-		"pretest": "npm run compile && npm run lint",
-		"lint": "eslint src --ext ts",
-		"test": "node ./out/test/runTest.js"
+			"vscode:prepublish": "npm run compile",
+			"compile": "tsc -p ./",
+			"watch": "tsc -watch -p ./",
+			"pretest": "npm run compile && npm run lint",
+			"lint": "eslint src --ext ts",
+			"test": "node ./out/test/runTest.js"
 	},
 	"devDependencies": {
-		"@types/vscode": "^1.74.0",
-		"@types/glob": "^8.0.0",
-		"@types/mocha": "^10.0.1",
-		"@types/node": "16.x",
-		"@typescript-eslint/eslint-plugin": "^5.45.0",
-		"@typescript-eslint/parser": "^5.45.0",
-		"eslint": "^8.28.0",
-		"glob": "^8.0.3",
-		"mocha": "^10.1.0",
-		"typescript": "^4.9.3",
-		"@vscode/test-electron": "^2.2.0"
+			"@types/vscode": "^1.74.0",
+			"@types/glob": "^8.0.0",
+			"@types/mocha": "^10.0.1",
+			"@types/node": "16.x",
+			"@typescript-eslint/eslint-plugin": "^5.45.0",
+			"@typescript-eslint/parser": "^5.45.0",
+			"eslint": "^8.28.0",
+			"glob": "^8.0.3",
+			"mocha": "^10.1.0",
+			"typescript": "^4.9.3",
+			"@vscode/test-electron": "^2.2.0"
 	}
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -15,7 +15,7 @@ export enum Settings {
     FoldedTextColor = "foldedTextColor",
     FoldedTextBackgroundColor = "foldedTextBackgroundColor",
     UnfoldedTextOpacity = "unfoldedTextOpacity",
-		FoldLengthThreshold = "foldLengthThreshold"
+	FoldLengthThreshold = "foldLengthThreshold"
 }
 
 export function set(key: Settings, value: any) {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -15,6 +15,7 @@ export enum Settings {
     FoldedTextColor = "foldedTextColor",
     FoldedTextBackgroundColor = "foldedTextBackgroundColor",
     UnfoldedTextOpacity = "unfoldedTextOpacity",
+		FoldLengthThreshold = "foldLengthThreshold"
 }
 
 export function set(key: Settings, value: any) {

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -69,7 +69,7 @@ export class Decorator {
 
             const text = match[0]
             const textToFold = match[this.regExGroup]
-						const classNames = textToFold.split(" ")
+			const classNames = textToFold.split(" ")
             const foldStartIndex = text.indexOf(textToFold)
 
             const foldStartPosition = this.activeEditor.document.positionAt(match.index + foldStartIndex)
@@ -77,7 +77,7 @@ export class Decorator {
                 match.index + foldStartIndex + textToFold.length
             )
             const range = new Range(foldStartPosition, foldEndPosition)
-						const foldLengthThreshold = Config.get<number>(Settings.FoldLengthThreshold) ?? 0
+			const foldLengthThreshold = Config.get<number>(Settings.FoldLengthThreshold) ?? 0
             if (
                 !this.autoFold ||
                 this.isRangeSelected(range) ||
@@ -86,11 +86,11 @@ export class Decorator {
                 this.unfoldedRanges.push(range)
                 continue
             }
-						if (classNames.length <= foldLengthThreshold) {
-							// If the length of textToFold is less than or equal to the threshold, skip folding
-							this.unfoldedRanges.push(range)
-							continue
-						}
+			if (classNames.length <= foldLengthThreshold) {
+				// If the length of textToFold is less than or equal to the threshold, skip folding
+				this.unfoldedRanges.push(range)
+				continue
+			}
             this.foldedRanges.push(range)
         }
 

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -69,6 +69,7 @@ export class Decorator {
 
             const text = match[0]
             const textToFold = match[this.regExGroup]
+						const classNames = textToFold.split(" ")
             const foldStartIndex = text.indexOf(textToFold)
 
             const foldStartPosition = this.activeEditor.document.positionAt(match.index + foldStartIndex)
@@ -76,7 +77,7 @@ export class Decorator {
                 match.index + foldStartIndex + textToFold.length
             )
             const range = new Range(foldStartPosition, foldEndPosition)
-
+						const foldLengthThreshold = Config.get<number>(Settings.FoldLengthThreshold) ?? 0
             if (
                 !this.autoFold ||
                 this.isRangeSelected(range) ||
@@ -85,7 +86,11 @@ export class Decorator {
                 this.unfoldedRanges.push(range)
                 continue
             }
-
+						if (classNames.length <= foldLengthThreshold) {
+							// If the length of textToFold is less than or equal to the threshold, skip folding
+							this.unfoldedRanges.push(range)
+							continue
+						}
             this.foldedRanges.push(range)
         }
 


### PR DESCRIPTION
This pull request addresses issue #7. It modifies the folding behavior in the Decorator class by introducing the `foldLengthThreshold` configuration setting. The `foldLengthThreshold` specifies the minimum number of classes required for a section to be unfolded instead of folded.

Here are the changes made in this pull request:

diff --git a/README.md b/README.md

Added the `foldLengthThreshold` configuration setting to the list of supported settings in the README file.
diff --git a/src/configuration.ts b/src/configuration.ts

Added the `FoldLengthThreshold` enum value to the Settings enum in the configuration.ts file.
diff --git a/src/decorator.ts b/src/decorator.ts

Added code to split the textToFold into individual class names.
Introduced the `foldLengthThreshold` variable, which retrieves the value of the `FoldLengthThreshold` setting.
Skips folding if the number of class names is less than or equal to the `foldLengthThreshold`.
Please review these changes and consider merging them into the main branch. Let me know if you have any questions or require further clarification.

Fixes #7