### PR TITLE
Add ability to fold with opacity

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,20 @@
                     "type": "number",
                     "default": 0,
                     "description": "Specifies the minimum number of class attributes required for a section to fold"
+                },
+                "tailwind-fold.replaceText": {
+                    "order": 11,
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to enable text replacement at all (reduce \"foldedTextOpacity\" to fold with opacity)"
+                },
+                "tailwind-fold.foldedTextOpacity": {
+                    "order": 12,
+                    "type": "number",
+                    "default": 1,
+                    "description": "Class attribute opacity when folded",
+                    "minimum": 0,
+                    "maximum": 1
                 }
             }
         }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -7,6 +7,7 @@ export enum Settings {
     AutoFold = "autoFold",
     UnfoldIfLineSelected = "unfoldIfLineSelected",
     SupportedLanguages = "supportedLanguages",
+    ReplaceText = "replaceText",
 
     // Visuals
     FoldStyle = "foldStyle",
@@ -14,6 +15,7 @@ export enum Settings {
     FoldedText = "foldedText",
     FoldedTextColor = "foldedTextColor",
     FoldedTextBackgroundColor = "foldedTextBackgroundColor",
+    FoldedTextOpacity = "foldedTextOpacity",
     UnfoldedTextOpacity = "unfoldedTextOpacity",
     FoldLengthThreshold = "foldLengthThreshold",
 }

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -31,18 +31,29 @@ export function UnfoldedDecorationType() {
 }
 
 export function FoldedDecorationType() {
+    const replaceTextEnabled = Config.get<boolean>(Settings.ReplaceText)
+    const foldedOpacity = Config.get<number>(Settings.FoldedTextOpacity).toString()
+
+    if (replaceTextEnabled) {
+        return window.createTextEditorDecorationType({
+            before: {
+                contentIconPath:
+                    Config.get<boolean>(Settings.ShowTailwindImage) === true ? generateScaledSVGPath() : undefined,
+                backgroundColor: Config.get<string>(Settings.FoldedTextBackgroundColor) ?? "transparent",
+                margin: "0 0 0 -5px",
+                textDecoration: `none; opacity: ${foldedOpacity}`,
+            },
+            after: {
+                contentText: Config.get<string>(Settings.FoldedText) ?? "class",
+                backgroundColor: Config.get<string>(Settings.FoldedTextBackgroundColor) ?? "transparent",
+                color: Config.get<string>(Settings.FoldedTextColor) ?? "#7cdbfe7e",
+                textDecoration: `none; opacity: ${foldedOpacity}`,
+            },
+            textDecoration: "none; display: none;",
+        })
+    }
+
     return window.createTextEditorDecorationType({
-        before: {
-            contentIconPath:
-                Config.get<boolean>(Settings.ShowTailwindImage) === true ? generateScaledSVGPath() : undefined,
-            backgroundColor: Config.get<string>(Settings.FoldedTextBackgroundColor) ?? "transparent",
-            margin: "0 0 0 -5px",
-        },
-        after: {
-            contentText: Config.get<string>(Settings.FoldedText) ?? "class",
-            backgroundColor: Config.get<string>(Settings.FoldedTextBackgroundColor) ?? "transparent",
-            color: Config.get<string>(Settings.FoldedTextColor) ?? "#7cdbfe7e",
-        },
-        textDecoration: "none; display: none;",
+        opacity: foldedOpacity,
     })
 }


### PR DESCRIPTION
Related to #29 

To achieve "opacity-only" folding you can do:

```
{
  "tailwind-fold.replaceText": false,
  "tailwind-fold.foldedTextOpacity": 0.5
}
```

![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExeXd6OGs0b3Y0YnplNXlqZzB3YXFrb2FnampuYTM1cDl5OW5lajd4ayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/MT3QTRrVIMzkQ4YzqR/giphy.gif)