### PR TITLE
feat: add Ember support

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,10 @@
                         "coffeescript",
                         "svelte",
                         "astro",
-                        "erb"
+                        "erb",
+                        "handlebars",
+                        "glimmer-js",
+                        "glimmer-ts"
                     ],
                     "description": "Supported languages"
                 },


### PR DESCRIPTION
Adds support for Ember template.

- Classic templates in Handlebars files (`.hbs`)
- Template tag components (`.gjs`/`.gts`)

This is supported by the official Tailwind VS Code plugin as well. (https://github.com/tailwindlabs/tailwindcss-intellisense/pull/867)

<img width="498" alt="image" src="https://github.com/user-attachments/assets/e54df594-b612-461b-981b-06158cafcc76">
