### PR TITLE
Fix regex to better match ERB syntax

### DIFF
--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -11,7 +11,7 @@ export class Decorator {
     unfoldIfLineSelected: boolean = false
     supportedLanguages: string[] = []
 
-    regEx = /(class|className)(?:=|:|:\s)((({\s*?.*?\()([\s\S]*?)(\)\s*?}))|(({?\s*?(['"`]))([\s\S]*?)(\8|\9\s*?})))/g
+    regEx = /(class|className)(?:=|:|:\s)((({\s*?.*?\()([\s\S]*?)(\)\s*?}))|({?\s*?["'`])([\s\S]*?)(["'`]\s*?}?))/g
     regExGroupsAll = [0]
     regExGroupsQuotes = [5, 10]
     regExGroups = this.regExGroupsAll


### PR DESCRIPTION
Old regex has issues and matches multiple lines

<img width="984" alt="image" src="https://github.com/user-attachments/assets/bf55652d-0985-42ba-bab3-1a7834c2a3a7">

Updated regex matches correctly

<img width="979" alt="image" src="https://github.com/user-attachments/assets/9c6c80e1-a2e6-41f6-a4c3-9445795d56f8">

@stivoat what is the process to get this tested and released?